### PR TITLE
Fixing bugs in the onbjerg ast

### DIFF
--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -557,7 +557,7 @@ async fn can_abiencoderv2_output() {
     assert_eq!(res, person);
 }
 
-/*#[test]
+#[test]
 fn can_gen_multi_etherscan() {
     abigen!(
         MyContract, "etherscan:0xdAC17F958D2ee523a2206206994597C13D831ec7";
@@ -567,7 +567,7 @@ fn can_gen_multi_etherscan() {
     let provider = Arc::new(Provider::new(MockProvider::new()));
     let _contract = MyContract::new(Address::default(), Arc::clone(&provider));
     let _contract = MyContract2::new(Address::default(), provider);
-}*/
+}
 
 #[test]
 fn can_gen_reserved_word_field_names() {

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -557,7 +557,7 @@ async fn can_abiencoderv2_output() {
     assert_eq!(res, person);
 }
 
-#[test]
+/*#[test]
 fn can_gen_multi_etherscan() {
     abigen!(
         MyContract, "etherscan:0xdAC17F958D2ee523a2206206994597C13D831ec7";
@@ -567,7 +567,7 @@ fn can_gen_multi_etherscan() {
     let provider = Arc::new(Provider::new(MockProvider::new()));
     let _contract = MyContract::new(Address::default(), Arc::clone(&provider));
     let _contract = MyContract2::new(Address::default(), provider);
-}
+}*/
 
 #[test]
 fn can_gen_reserved_word_field_names() {

--- a/ethers-solc/src/artifacts/ast/macros.rs
+++ b/ethers-solc/src/artifacts/ast/macros.rs
@@ -40,9 +40,13 @@ macro_rules! expr_node {
             struct $name {
                 #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
                 argument_types: Vec<TypeDescriptions>,
+                #[serde(default)]
                 is_constant: bool,
+                #[serde(default)]
                 is_l_value: bool,
+                #[serde(default)]
                 is_pure: bool,
+                #[serde(default)]
                 l_value_requested: bool,
                 type_descriptions: TypeDescriptions,
                 $(

--- a/ethers-solc/src/artifacts/ast/misc.rs
+++ b/ethers-solc/src/artifacts/ast/misc.rs
@@ -34,7 +34,7 @@ impl FromStr for SourceLocation {
             .parse::<isize>()
             .map_err(|_| invalid_location())?;
 
-        let start = if start < 0 { None } else { Some(length as usize) };
+        let start = if start < 0 { None } else { Some(start as usize) };
         let length = if length < 0 { None } else { Some(length as usize) };
         let index = if index < 0 { None } else { Some(index as usize) };
 

--- a/ethers-solc/src/artifacts/ast/mod.rs
+++ b/ethers-solc/src/artifacts/ast/mod.rs
@@ -307,6 +307,9 @@ pub enum BinaryOperator {
     /// Bitwise xor (`^`)
     #[serde(rename = "^")]
     Xor,
+    /// Bitwise not (`~`)
+    #[serde(rename = "~")]
+    BitNot,
     /// Bitwise and (`&`)
     #[serde(rename = "&")]
     BitAnd,
@@ -410,7 +413,7 @@ expr_node!(
     /// An index access.
     struct IndexAccess {
         base_expression: Expression,
-        index_expression: Expression,
+        index_expression: Option<Expression>,
     }
 );
 
@@ -626,6 +629,9 @@ pub enum UnaryOperator {
     /// Not (`!`)
     #[serde(rename = "!")]
     Not,
+    /// Bitwise not (`~`)
+    #[serde(rename = "~")]
+    BitNot,
     /// `delete`
     #[serde(rename = "delete")]
     Delete,
@@ -872,6 +878,8 @@ pub struct ExternalInlineAssemblyReference {
     pub offset: bool,
     #[serde(default)]
     pub slot: bool,
+    #[serde(default)]
+    pub length: bool,
     pub value_size: usize,
     pub suffix: Option<AssemblyReferenceSuffix>,
 }
@@ -884,6 +892,8 @@ pub enum AssemblyReferenceSuffix {
     Slot,
     /// The reference refers to an offset.
     Offset,
+    /// The reference refers to a length.
+    Length,
 }
 
 /// Inline assembly flags.

--- a/ethers-solc/test-data/ast/bit_not.json
+++ b/ethers-solc/test-data/ast/bit_not.json
@@ -1,0 +1,390 @@
+{
+  "absolutePath": "Bytes.sol",
+  "exportedSymbols":
+  {
+    "Bytes":
+    [
+      25
+    ]
+  },
+  "id": 26,
+  "license": "UNLICENSED",
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 1,
+      "literals":
+      [
+        "solidity",
+        "0.8",
+        ".13"
+      ],
+      "nodeType": "PragmaDirective",
+      "src": "40:23:0"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "Bytes",
+      "contractDependencies": [],
+      "contractKind": "library",
+      "fullyImplemented": true,
+      "id": 25,
+      "linearizedBaseContracts":
+      [
+        25
+      ],
+      "name": "Bytes",
+      "nameLocation": "73:5:0",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 23,
+            "nodeType": "Block",
+            "src": "207:164:0",
+            "statements":
+            [
+              {
+                "expression":
+                {
+                  "commonType":
+                  {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  },
+                  "id": 21,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "leftExpression":
+                  {
+                    "id": 12,
+                    "name": "_packedBools",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 3,
+                    "src": "314:12:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint192",
+                      "typeString": "uint192"
+                    }
+                  },
+                  "nodeType": "BinaryOperation",
+                  "operator": "&",
+                  "rightExpression":
+                  {
+                    "id": 20,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "~",
+                    "prefix": true,
+                    "src": "329:28:0",
+                    "subExpression":
+                    {
+                      "components":
+                      [
+                        {
+                          "commonType":
+                          {
+                            "typeIdentifier": "t_uint192",
+                            "typeString": "uint192"
+                          },
+                          "id": 18,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression":
+                          {
+                            "arguments":
+                            [
+                              {
+                                "hexValue": "31",
+                                "id": 15,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "kind": "number",
+                                "lValueRequested": false,
+                                "nodeType": "Literal",
+                                "src": "339:1:0",
+                                "typeDescriptions":
+                                {
+                                  "typeIdentifier": "t_rational_1_by_1",
+                                  "typeString": "int_const 1"
+                                },
+                                "value": "1"
+                              }
+                            ],
+                            "expression":
+                            {
+                              "argumentTypes":
+                              [
+                                {
+                                  "typeIdentifier": "t_rational_1_by_1",
+                                  "typeString": "int_const 1"
+                                }
+                              ],
+                              "id": 14,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "331:7:0",
+                              "typeDescriptions":
+                              {
+                                "typeIdentifier": "t_type$_t_uint192_$",
+                                "typeString": "type(uint192)"
+                              },
+                              "typeName":
+                              {
+                                "id": 13,
+                                "name": "uint192",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "331:7:0",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 16,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "331:10:0",
+                            "tryCall": false,
+                            "typeDescriptions":
+                            {
+                              "typeIdentifier": "t_uint192",
+                              "typeString": "uint192"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "<<",
+                          "rightExpression":
+                          {
+                            "id": 17,
+                            "name": "_boolNumber",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 5,
+                            "src": "345:11:0",
+                            "typeDescriptions":
+                            {
+                              "typeIdentifier": "t_uint192",
+                              "typeString": "uint192"
+                            }
+                          },
+                          "src": "331:25:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_uint192",
+                            "typeString": "uint192"
+                          }
+                        }
+                      ],
+                      "id": 19,
+                      "isConstant": false,
+                      "isInlineArray": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "nodeType": "TupleExpression",
+                      "src": "330:27:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint192",
+                        "typeString": "uint192"
+                      }
+                    },
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint192",
+                      "typeString": "uint192"
+                    }
+                  },
+                  "src": "314:43:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "functionReturnParameters": 11,
+                "id": 22,
+                "nodeType": "Return",
+                "src": "307:50:0"
+              }
+            ]
+          },
+          "id": 24,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "setBoolean",
+          "nameLocation": "92:10:0",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 8,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 3,
+                "mutability": "mutable",
+                "name": "_packedBools",
+                "nameLocation": "116:12:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "108:20:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint192",
+                  "typeString": "uint192"
+                },
+                "typeName":
+                {
+                  "id": 2,
+                  "name": "uint192",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "108:7:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 5,
+                "mutability": "mutable",
+                "name": "_boolNumber",
+                "nameLocation": "142:11:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "134:19:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint192",
+                  "typeString": "uint192"
+                },
+                "typeName":
+                {
+                  "id": 4,
+                  "name": "uint192",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "134:7:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 7,
+                "mutability": "mutable",
+                "name": "_value",
+                "nameLocation": "164:6:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "159:11:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_bool",
+                  "typeString": "bool"
+                },
+                "typeName":
+                {
+                  "id": 6,
+                  "name": "bool",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "159:4:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "102:72:0"
+          },
+          "returnParameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 10,
+                "mutability": "mutable",
+                "name": "",
+                "nameLocation": "-1:-1:-1",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "198:7:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint192",
+                  "typeString": "uint192"
+                },
+                "typeName":
+                {
+                  "id": 9,
+                  "name": "uint192",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "198:7:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "197:9:0"
+          },
+          "scope": 25,
+          "src": "83:288:0",
+          "stateMutability": "pure",
+          "virtual": false,
+          "visibility": "internal"
+        }
+      ],
+      "scope": 26,
+      "src": "65:308:0",
+      "usedErrors": []
+    }
+  ],
+  "src": "40:334:0"
+}


### PR DESCRIPTION
Fixing minors bugs in the https://github.com/gakonst/ethers-rs/pull/1567 PR.

- Some fields were not serialized correctly
- In the `SourceLocation`, start was always equal to length
- Forgot the bit-wise "not" `~` expression
- In some case the index expression is optional